### PR TITLE
Vertical-alignment in table cells

### DIFF
--- a/css/github.css
+++ b/css/github.css
@@ -267,6 +267,7 @@ body table {
 body td,
 body th {
   padding: 0;
+  vertical-align: top;
 }
 
 body h1,


### PR DESCRIPTION
So you can just do something like this in standard Github-flavoured markdown...

```
| Item Column Heading | Description Column Heading                 |
|---------------------|--------------------------------------------|
| Item 1              | Description Line 1<br/>Description Line 2  |
```

At present you have to do something like this:

```
| Item Column Heading | Description Column Heading                 |
|---------------------|--------------------------------------------|
| Item 1<br/>&nbsp;   | Description Line 1<br/>Description Line 2  |
```

(Changes could be applied to solarized-* too.()