### PR TITLE
Enable passing extra args to live-server

### DIFF
--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -59,12 +59,13 @@ function! s:LiveServer.start(root, index_path)
   if !exists('self.pid')
     let mount_path = fnamemodify(a:index_path, ':h')
     let index = fnamemodify(a:index_path, ':t')
+    let extra_opts = get(g:, 'nvim_markdown_preview_liveserver_extra_args', [])
     let self.pid = jobstart([
           \ 'live-server',
           \ '--quiet',
           \ '--mount='.'/:'.mount_path,
           \ '--open='.index,
-          \ ],
+          \ ] + extra_opts,
           \ self,
           \ )
   endif

--- a/doc/nvim-markdown-preview.txt
+++ b/doc/nvim-markdown-preview.txt
@@ -58,4 +58,11 @@ The default is `gfm` (Github flavored markdown).
   let g:nvim_markdown_preview_format = 'markdown'
 <
 
+Set this variable to pass any additional options to live-server.
+
+>
+  let g:nvim_markdown_preview_liveserver_extra_args =
+      \ ['--browser=librewolf', '--port=9999']
+<
+
  vim:tw=78:et:ft=help:norl:


### PR DESCRIPTION
This enables a high degree of customization. I've found it useful for changing the browser being opened, and changing the port on which the live server is started.

Similar to #18, but for live-server. Fixes #16.