### PR TITLE
Pass input file's directory as live-server's root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nvim-markdown-preview
 
-Markdown preview in the browser using [pandoc](https://pandoc.org/) and [live-server](https://github.com/tapio/live-server) through Neovim's [job-control API](https://neovim.io/doc/user/job_control.html).
+Markdown preview in the browser using [pandoc](https://pandoc.org/) and [live-server](https://github.com/compodoc/live-server) through Neovim's [job-control API](https://neovim.io/doc/user/job_control.html).
 
 ## Usage
 

--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -59,12 +59,13 @@ function! s:LiveServer.start(root, index_path)
   if !exists('self.pid')
     let mount_path = fnamemodify(a:index_path, ':h')
     let index = fnamemodify(a:index_path, ':t')
+    let extra_opts = get(g:, 'nvim_markdown_preview_liveserver_extra_args', [])
     let self.pid = jobstart([
           \ 'live-server',
           \ '--quiet',
           \ '--mount='.'/:'.mount_path,
           \ '--open='.index,
-          \ ],
+          \ ] + extra_opts,
           \ self,
           \ )
   endif

--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -65,7 +65,7 @@ function! s:LiveServer.start(root, index_path)
           \ '--quiet',
           \ '--mount='.'/:'.mount_path,
           \ '--open='.index,
-          \ ] + extra_opts,
+          \ ] + extra_opts + [a:root],
           \ self,
           \ )
   endif

--- a/doc/nvim-markdown-preview.txt
+++ b/doc/nvim-markdown-preview.txt
@@ -58,4 +58,11 @@ The default is `gfm` (Github flavored markdown).
   let g:nvim_markdown_preview_format = 'markdown'
 <
 
+Set this variable to pass any additional options to live-server.
+
+>
+  let g:nvim_markdown_preview_liveserver_extra_args =
+      \ ['--browser=librewolf', '--port=9999']
+<
+
  vim:tw=78:et:ft=help:norl:

--- a/doc/nvim-markdown-preview.txt
+++ b/doc/nvim-markdown-preview.txt
@@ -6,7 +6,7 @@ License: GPL3
 INTRODUCTION                                           *nvim-markdown-preview*
 
 Markdown preview in the browser using pandoc (https://pandoc.org/) and
-live-server (https://github.com/tapio/live-server) through Neovim's
+live-server (https://github.com/compdoc/live-server) through Neovim's
 |job-control| API.
 
 


### PR DESCRIPTION
:warning: **This PR includes changes from #20, so it should be reviewed and merged before this one.**

This fixes broken relative links when previewing files outside of the current working directory.

Example: Open a terminal and `cd` to the parent directory of your clone of this repo, run `nvim nvim-markdown-preview/README.md`, and `:MarkdowPreview<CR>`. Notice how the screenshot is missing.

This happens because the generated HTML's (temporary) directory is mounted at the live server's `/`. This is required for the HTML file to be accessible to live-server, but it also means that relative links are broken, because the temp directory doesn't contain linked resources.

Previewing files in the current directory happens to work, because live-server's root is the current directory, which live-server
apparently [falls back to](https://github.com/compodoc/live-server/blob/741b26c115d423e04936872c16831950cb83ba06/index.js#L279=) when it can't find something in the directory [mounted at `/`](https://github.com/compodoc/live-server/blob/741b26c115d423e04936872c16831950cb83ba06/index.js#L265=). (The server root and `/` mounts both appear to be mapped.)

This fallback functionality is leveraged to fix relative resource links by setting the live-server root to the directory of the input file.